### PR TITLE
Fix t/app.t failure when CPAN_MINI_CONFIG defined

### DIFF
--- a/t/app.t
+++ b/t/app.t
@@ -9,6 +9,8 @@ use File::Temp qw(tempdir);
 my $TARGET  = tempdir(CLEANUP => 1);
 my @LR_ARGS = (qw(--offline -r http://example.tld/cpan -l), $TARGET);
 
+delete $ENV{CPAN_MINI_CONFIG};
+
 sub config_dir {
   my ($config) = @_;
 


### PR DESCRIPTION
Hi Ricardo,

I have my .minicpanrc file in a non-standard location, and have CPAN_MINI_CONFIG defined in my .bashrc.

With CPAN_MINI_CONFIG defined I get these test failures:

```
t/app.t ................. 1/?
  #   Failed test 'debug from config file'
  #   at t/app.t line 58.
  #          got: 'info'
  #     expected: 'debug'
  # Looks like you failed 1 test of 2.

#   Failed test 'config: log_level'
#   at t/app.t line 59.
# Looks like you failed 1 test of 8.
```

You can repro it easy enough with: CPAN_MINI_CONFIG=something dzil test

This patch just deletes $ENV{CPAN_MINI_CONFIG} in t/app.t so the intended config file gets loaded.

Cheers,
Steve
