### PR TITLE
Add support for XDG Base Directory specification

### DIFF
--- a/bin/minicpan
+++ b/bin/minicpan
@@ -14,8 +14,8 @@ __END__
  minicpan [options]
 
  Options
-   -l LOCAL    - where is the local minicpan?     (required)
-   -r REMOTE   - where is the remote cpan mirror? (required)
+   -l LOCAL    - where is the local minicpan?
+   -r REMOTE   - where is the remote cpan mirror?
    -d 0###     - permissions (numeric) to use when creating directories
    -f          - check all directories, even if indices are unchanged
    -p          - mirror perl, ponie, and parrot distributions
@@ -23,7 +23,7 @@ __END__
    -q          - run in quiet mode (don't print status)
    -qq         - run in silent mode (don't even print warnings)
    -c CLASS    - what class to use to mirror (default: CPAN::Mini)
-   -C FILE     - what config file to use (default: ~/.minicpanrc)
+   -C FILE     - what config file to use
    -h          - print help and exit
    -v          - print version and exit
    -x          - build an exact mirror, getting even normally disallowed files
@@ -36,6 +36,13 @@ __END__
 
 This simple shell script just updates (or creates) a miniature CPAN mirror as
 described in CPAN::Mini.
+
+=head1 LOCAL MINICPAN LOCATION
+
+C<minicpan> will create the local minicpan in F<$XDG_CACHE_HOME/minicpan> by
+default, or F<$HOME/.cache/minicpan> if C<XDG_CACHE_HOME> is not set. This can
+be changed with the c<-l> command line option or by specifying a directory in
+the configuration file.
 
 =head1 CONFIGURATION FILE
 
@@ -55,6 +62,8 @@ It takes the first defined it finds:
 =item * Use the value specified by C<-C> on the command line
 
 =item * Use the value in the C<CPAN_MINI_CONFIG> environment variable
+
+=item * Use F<$XDG_CONFIG_HOME/minicpan/config>, or use F<$HOME/.config/minicpan/config> if C<XDG_CONFIG_HOME> is not set
 
 =item * Use F<~/.minicpanrc>
 

--- a/lib/CPAN/Mini.pm
+++ b/lib/CPAN/Mini.pm
@@ -44,6 +44,7 @@ use File::Find ();
 use File::Path 2.04 ();     # new API, bugfixes
 use File::Spec ();
 use File::Temp ();
+use File::BaseDir ();
 
 use URI 1            ();
 use LWP::UserAgent 5 ();
@@ -74,7 +75,9 @@ The following options are recognized:
 
 * C<local>
 
-This is the local file path where the mirror will be written or updated.
+This is the local file path where the mirror will be written or updated. It
+defaults to F<$XDG_CACHE_HOME/minicpan>, or F<$HOME/.cache/minicpan> if
+C<XDG_CACHE_HOME> is not set.
 
 * C<remote>
 
@@ -288,7 +291,8 @@ sub new {
 
   $self->{recent} = {};
 
-  Carp::croak "no local mirror supplied" unless $self->{local};
+  my $xdg = File::BaseDir->new();
+  $self->{local} ||= File::Spec->catfile($xdg->xdg_cache_home(), 'minicpan');
 
   substr($self->{local}, 0, 1, $class->__homedir)
     if substr($self->{local}, 0, 1) eq q{~};
@@ -700,8 +704,8 @@ sub log_debug {
 
 This routine returns a set of arguments that can be passed to CPAN::Mini's
 C<new> or C<update_mirror> methods.  It will look for a file called
-F<.minicpanrc> in the user's home directory as determined by
-L<File::HomeDir|File::HomeDir>.
+F<$XDG_CONFIG_HOME/minicpan/config> or F<.minicpanrc> in the user's home
+directory as determined by L<File::HomeDir|File::HomeDir>.
 
 =cut
 
@@ -718,6 +722,12 @@ sub __homedir {
 
 sub __homedir_configfile {
   my ($class) = @_;
+
+  my $xdg = File::BaseDir->new();
+  my $xdg_config = File::Spec->catfile($xdg->xdg_config_home(), 'minicpan', 'config');
+  if (-e $xdg_config) {
+    return $xdg_config;
+  }
   my $default = File::Spec->catfile($class->__homedir, '.minicpanrc');
 }
 
@@ -790,9 +800,10 @@ sub read_config {
 
 This routine returns the config file name. It first looks at for the
 C<config_file> setting, then the C<CPAN_MINI_CONFIG> environment
-variable, then the default F<~/.minicpanrc>, and finally the
-F<CPAN/Mini/minicpan.conf>. It uses the first defined value it finds.
-If the filename it selects does not exist, it returns false.
+variable, then F<$XDG_CONFIG_HOME/minicpan/config> or
+F<$HOME/.config/minicpan/config>, then the default F<~/.minicpanrc>, and
+finally the F<CPAN/Mini/minicpan.conf>. It uses the first defined value
+it finds. If the filename it selects does not exist, it returns false.
 
 OPTIONS is an optional hash reference of the C<CPAN::Mini> config hash.
 

--- a/lib/CPAN/Mini/App.pm
+++ b/lib/CPAN/Mini/App.pm
@@ -107,8 +107,6 @@ sub initialize_minicpan {
 
   $config{remote} ||= 'http://www.cpan.org/';
 
-  pod2usage(2) unless $config{local} and $config{remote};
-
   $|++;
 
   # Convert dirmode string to a real octal value, if given


### PR DESCRIPTION
Add support for the XDG Base Directory specification as defined at
https://specifications.freedesktop.org/basedir-spec/latest/.

The config file located at $XDG_CONFIG_HOME/minicpan/config will be
checked before looking for ~/.minicpanrc.

$XDG_CACHE_HOME/minicpan will be used as the local minicpan directory if
local is not defined on the command line or in the configuration file.

Remove the check for $config{local} and $config{remote} in App.pm. The
software already defaults to http://www.cpan.org/ if a remote is not
specified.